### PR TITLE
Fix imports in auth screen

### DIFF
--- a/lib/screens/auth_screen.dart
+++ b/lib/screens/auth_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'constants.dart';
-import 'screens/menu_screen.dart';
+import '../constants.dart';
+import 'menu_screen.dart';
 
 class AuthScreen extends StatefulWidget {
   const AuthScreen({super.key});


### PR DESCRIPTION
## Summary
- fix relative imports in `auth_screen.dart`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555a5c584083269fb1f8cb3d9035ae